### PR TITLE
Add Prefix option

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -14,3 +14,4 @@ Inside your fieldset, simply use `type: uuid` and a UUID will be generated for t
 |------|---------|-------------|
 | `hidden` | `false` | Hide the field from the CP while still generating a UUID. |
 | `readonly` | `false` | Set the input to readonly, stopping the user from editing the field. |
+| `prefix` | `''` | Add a prefix to the ID |

--- a/Uuid/UuidFieldtype.php
+++ b/Uuid/UuidFieldtype.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Addons\Uuid;
 
-use Statamic\API\Str;
 use Statamic\Extend\Fieldtype;
 
 class UuidFieldtype extends Fieldtype
@@ -38,13 +37,6 @@ class UuidFieldtype extends Fieldtype
      */
     public function process($data)
     {
-        // if there's a prefix in the config && there's no prefix in the data, then add it
-        $prefix = $this->getFieldConfig('prefix', null);
-
-        if ($prefix && !Str::startsWith($data, $prefix)) {
-            return $prefix . $data;
-        }
-
         return $data;
     }
 }

--- a/Uuid/UuidFieldtype.php
+++ b/Uuid/UuidFieldtype.php
@@ -2,10 +2,13 @@
 
 namespace Statamic\Addons\Uuid;
 
+use Statamic\API\Str;
 use Statamic\Extend\Fieldtype;
 
 class UuidFieldtype extends Fieldtype
 {
+    public $category = ['special'];
+
     /**
      * The blank/default value
      *
@@ -35,6 +38,13 @@ class UuidFieldtype extends Fieldtype
      */
     public function process($data)
     {
+        // if there's a prefix in the config && there's no prefix in the data, then add it
+        $prefix = $this->getFieldConfig('prefix', null);
+
+        if ($prefix && !Str::startsWith($data, $prefix)) {
+            return $prefix . $data;
+        }
+
         return $data;
     }
 }

--- a/Uuid/meta.yaml
+++ b/Uuid/meta.yaml
@@ -1,6 +1,16 @@
 name: Uuid
-version: 1.1
+version: 1.2
 description: One of its kind; unlike anything else
 url: https://statamic.com/marketplace/addons/uuid
 developer: Series Eight
 developer_url: https://serieseight.com
+fieldtype_fields:
+  readonly:
+    type: toggle
+    width: 33
+  hidden:
+    type: toggle
+    width: 33
+  prefix:
+    type: text
+    width: 33

--- a/Uuid/resources/assets/js/fieldtype.js
+++ b/Uuid/resources/assets/js/fieldtype.js
@@ -4,20 +4,23 @@ Vue.component('uuid-fieldtype', {
   template: '<div><input class="form-control" :class="{ \'bg-grey-light\': readonly }" v-model="data" :type="type" :readonly="readonly"></div>',
 
   computed: {
-    type: function() {
+    type: function () {
       return this.config.hidden ? 'hidden' : 'text'
     },
-    readonly: function() {
+    readonly: function () {
       return this.config.readonly || false
+    },
+    prefix: function () {
+      return this.config.prefix || ''
     },
   },
 
   methods: {
-    hide: function() {
+    hide: function () {
       var el = this.$el
       var uuidClass = 'uuid-fieldtype'
 
-      while (! el.classList.contains(uuidClass) && el.parentNode) {
+      while (!el.classList.contains(uuidClass) && el.parentNode) {
         el = el.parentNode
       }
 
@@ -27,11 +30,11 @@ Vue.component('uuid-fieldtype', {
     },
   },
 
-  created: function() {
-    this.data = this.data || uuidv4()
+  created: function () {
+    this.data = this.data || this.prefix + uuidv4()
   },
 
-  ready: function() {
+  ready: function () {
     if (this.config.hidden) {
       this.hide()
     }

--- a/Uuid/resources/lang/en/fieldtypes.php
+++ b/Uuid/resources/lang/en/fieldtypes.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'readonly' => 'Read-only?',
+    'readonly_instruct' => "Toggle this to true if you'd like to make the UUID readonly",
+
+    'hidden' => 'Hidden?',
+    'hidden_instruct' => "Toggle this to true if you'd like to hide the UUID",
+
+    'prefix' => 'Prefix?',
+    'prefix_instruct' => 'Would you like to prefix the ID? Leave blank for no prefix',
+];


### PR DESCRIPTION
Ability to prefix the UUID.

Also exposed the config to the CP so that when you add this field type, you can choose `readonly`, `hidden` & `prefix`